### PR TITLE
Update QueryAsyncJobResultResponse Struct and WaitForAsyncJob() Error Message to Return the CSP Error string

### DIFF
--- a/async_job.go
+++ b/async_job.go
@@ -11,22 +11,26 @@ package ktcloudsdk
 
 import (
 	"net/url"
-	"encoding/json"
 )
+
+type JobResult struct {
+	ErrorCode int 	 `json:"errorcode"`
+	ErrorText string `json:"errortext"`
+}
 
 type QueryAsyncJobResultResponse struct {
 	Queryasyncjobresultresponse struct {
 		AccountId     	string  `json:"accountid"`
 		UserId        	string  `json:"userid"`
 		Cmd           	string  `json:"cmd"`
-		JobStatus     	int 	  `json:"jobstatus"`
-		JobProcStatus 	int 	  `json:"jobprocstatus"`
-		JobResultCode 	int	  `json:"jobresultcode"`
+		JobStatus     	int 	`json:"jobstatus"`
+		JobProcStatus 	int 	`json:"jobprocstatus"`
+		JobResultCode 	int	  	`json:"jobresultcode"`
 		JobResultType 	string  `json:"jobresulttype"`
 		State 		  	string  `json:"state"`
-		JobResult 		json.RawMessage `json:"jobresult"`
-		JobInstanceType string `json:"jobinstancetype"`
-		JobInstanceId 	string `json:"jobinstanceid"`
+		JobResult 		JobResult `json:"jobresult"`
+		JobInstanceType string 	`json:"jobinstancetype"`
+		JobInstanceId 	string 	`json:"jobinstanceid"`
 		Created       	string  `json:"created"`
 		JobId         	string  `json:"jobid"`
 	} `json:"queryasyncjobresultresponse"`

--- a/tag.go
+++ b/tag.go
@@ -15,24 +15,24 @@ import (
 	"strings"
 )
 
-type CreateTags struct {
-	ResourceIds  []string `json:"resourceids"`
+type CreateTagsReqInfo struct {
 	ResourceType string   `json:"resourcetype`
+	ResourceIds  []string `json:"resourceids"`
 	Tags         []TagArg `json:"tags`
 }
 
-type ListTags struct {
+type ListTagsReqInfo struct {
 	Account      string `json:"account"`
 	DomainId     string `json:"domainid"`
 	Key          string `json:"key"`
 	Value        string `json:"value`
-	ResourceIds  string `json:"resourceids"`
 	ResourceType string `json:"resourcetype`
+	ResourceIds  string `json:"resourceids"`
 }
 
-type DeleteTags struct {
-	ResourceIds  []string `json:"resourceids"`
+type DeleteTagsReqInfo struct {
 	ResourceType string   `json:"resourcetype`
+	ResourceIds  []string `json:"resourceids"`
 	Tags         []TagArg `json:"tags`
 }
 
@@ -42,7 +42,7 @@ type TagArg struct {
 }
 
 // Add tags to specified resources
-func (c KtCloudClient) CreateTags(options *CreateTags) (CreateTagsResponse, error) {
+func (c KtCloudClient) CreateTags(options *CreateTagsReqInfo) (CreateTagsResponse, error) {
 	var resp CreateTagsResponse
 	params := url.Values{}
 
@@ -63,7 +63,7 @@ func (c KtCloudClient) CreateTags(options *CreateTags) (CreateTagsResponse, erro
 }
 
 // Returns all items with a particular tag
-func (c KtCloudClient) ListTags(options *ListTags) (ListTagsResponse, error) {
+func (c KtCloudClient) ListTags(options *ListTagsReqInfo) (ListTagsResponse, error) {
 	var resp ListTagsResponse
 	params := url.Values{}
 
@@ -101,7 +101,7 @@ func (c KtCloudClient) ListTags(options *ListTags) (ListTagsResponse, error) {
 }
 
 // Remove tags from specified resources
-func (c KtCloudClient) DeleteTags(options *DeleteTags) (DeleteTagsResponse, error) {
+func (c KtCloudClient) DeleteTags(options *DeleteTagsReqInfo) (DeleteTagsResponse, error) {
 	var resp DeleteTagsResponse
 	params := url.Values{}
 

--- a/wait.go
+++ b/wait.go
@@ -45,7 +45,7 @@ func (c KtCloudClient) WaitForAsyncJob(jobId string, timeOut time.Duration) erro
 				result <- nil
 				return
 			case 2:
-				err := fmt.Errorf("WaitForAsyncJob() failed")
+				err := fmt.Errorf("WaitForAsyncJob() failed. : %s", response.Queryasyncjobresultresponse.JobResult.ErrorText)
 				result <- err
 				return
 			}


### PR DESCRIPTION
- Update QueryAsyncJobResultResponse Struct to Get the Error string
- Update WaitForAsyncJob() Error Message to Return the CSP Error string
- Rename Tag Struct Names